### PR TITLE
[MapleLib] fix cloning WzVectorProperty

### DIFF
--- a/MapleLib/WzLib/WzProperties/WzVectorProperty.cs
+++ b/MapleLib/WzLib/WzProperties/WzVectorProperty.cs
@@ -46,7 +46,7 @@ namespace MapleLib.WzLib.WzProperties {
 		}
 
 		public override WzImageProperty DeepClone() {
-			var clone = new WzVectorProperty(name, x, y);
+			var clone = new WzVectorProperty(name, x.Value, y.Value);
 			return clone;
 		}
 


### PR DESCRIPTION
if you edit the vector you cloned,
every new vector property that we pasted would be changed since they are same WzIntProperty